### PR TITLE
fix: resolve ConfigSearch failures and correct Biome config flag

### DIFF
--- a/.changeset/fix-markdown-config.md
+++ b/.changeset/fix-markdown-config.md
@@ -1,0 +1,15 @@
+---
+"@savvy-web/lint-staged": patch
+---
+
+Fix ConfigSearch failing to find config files and Biome config flag
+
+ConfigSearch fixes:
+
+- Add custom loaders for `.jsonc`, `.yaml`, and `.yml` extensions that cosmiconfig doesn't handle by default
+- Search `lib/configs/` directory first using direct file existence checks before falling back to cosmiconfig
+- Simplify `exists()` method to use `existsSync()` directly
+
+Biome fixes:
+
+- Change `--config=` to `--config-path=` to match Biome CLI expectations

--- a/src/handlers/Biome.ts
+++ b/src/handlers/Biome.ts
@@ -129,7 +129,7 @@ export class Biome {
 
 			const files = filtered.join(" ");
 			const flags = options.flags ?? [];
-			const configFlag = config ? `--config=${config}` : "";
+			const configFlag = config ? `--config-path=${config}` : "";
 
 			const cmd = [`${biomeCmd} check --write --no-errors-on-unmatched`, configFlag, ...flags, files]
 				.filter(Boolean)

--- a/src/handlers/PackageJson.ts
+++ b/src/handlers/PackageJson.ts
@@ -80,7 +80,7 @@ export class PackageJson {
 			// Return only the Biome formatting command
 			const files = filtered.join(" ");
 			const biomeCmd = options.biomeConfig
-				? `biome check --write --max-diagnostics=none --config=${options.biomeConfig} ${files}`
+				? `biome check --write --max-diagnostics=none --config-path=${options.biomeConfig} ${files}`
 				: `biome check --write --max-diagnostics=none ${files}`;
 
 			return biomeCmd;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -102,7 +102,7 @@ describe("Handler classes", () => {
 		it("should accept custom config", () => {
 			const handler = Biome.create({ config: "./custom-biome.json" });
 			const result = handler(["src/index.ts"]);
-			expect(result).toContain("--config=./custom-biome.json");
+			expect(result).toContain("--config-path=./custom-biome.json");
 		});
 
 		it("should have findConfig method", () => {
@@ -495,7 +495,10 @@ describe("Configuration utilities", () => {
 
 			// Test that the custom exclude is applied
 			const result = (handler as (f: readonly string[]) => string)(["src/index.ts", "custom/file.ts"]);
-			expect(result).toBe("biome check --write --no-errors-on-unmatched src/index.ts");
+			// ConfigSearch finds biome.jsonc in this repo, so --config flag is included
+			expect(result).toContain("biome check --write --no-errors-on-unmatched");
+			expect(result).toContain("src/index.ts");
+			expect(result).not.toContain("custom/file.ts");
 		});
 
 		it("should include custom handlers", () => {


### PR DESCRIPTION
## Summary

- Fix ConfigSearch failing to find `.jsonc`, `.yaml`, and `.yml` config files due to missing cosmiconfig loaders
- Change Biome handlers to use `--config-path=` instead of `--config=` to match Biome CLI expectations
- Search `lib/configs/` directory first using direct file existence checks before falling back to cosmiconfig

## Root Cause

The `ConfigSearch` utility had two issues:
1. cosmiconfig throws "Missing loader" errors for `.jsonc` files since it doesn't have a built-in loader for that extension
2. Directory prefixes in `searchPlaces` (like `lib/configs/.markdownlint-cli2.jsonc`) confused cosmiconfig's extension detection

The error was silently caught, causing the config search to return `found: false` even when config files existed.

## Test plan

- [x] All existing tests pass
- [x] Pre-commit hooks now correctly find config files in `lib/configs/`
- [x] Biome commands use correct `--config-path=` flag

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>